### PR TITLE
Add checking markdown links

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,12 @@
+name: Check Markdown links
+on: push
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        config-file: './.github/workflows/mlc_config.json'

--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,0 +1,9 @@
+{
+    "ignorePatterns": [
+        {
+            "pattern": "(.*\\.)?github.com*"
+        }
+    ],
+    "retryOn429": true,
+    "aliveStatusCodes": [200, 206]
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Learn RISC-V
 ================
-[![Check Markdown links](https://github.com/riscv/learn/actions/workflows/action.yml/badge.svg?branch=thong-phn%2Fcheck-markdown-links)](https://github.com/riscv/learn/actions/workflows/action.yml)
+[![Check Markdown links](https://github.com/riscv/learn/actions/workflows/action.yml/badge.svg?branch=main)](https://github.com/riscv/learn/actions/workflows/action.yml)
 
 A community-driven compilation of RISC-V resources and learning material. The list is dynamically
 updated by the community and categorized based on different contexts of the RISC-V scope, taking

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Learn RISC-V
 ================
+[![Check Markdown links](https://github.com/riscv/learn/actions/workflows/action.yml/badge.svg?branch=thong-phn%2Fcheck-markdown-links)](https://github.com/riscv/learn/actions/workflows/action.yml)
 
 A community-driven compilation of RISC-V resources and learning material. The list is dynamically
 updated by the community and categorized based on different contexts of the RISC-V scope, taking

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Learn RISC-V
 ================
 [![Check Markdown links](https://github.com/riscv/learn/actions/workflows/action.yml/badge.svg?branch=thong-phn%2Fcheck-markdown-links)](https://github.com/riscv/learn/actions/workflows/action.yml)
-
+[Fail Link](https://google.nett)
 A community-driven compilation of RISC-V resources and learning material. The list is dynamically
 updated by the community and categorized based on different contexts of the RISC-V scope, taking
 also into account different levels of experience/knowledge, allowing anyone interested in RISC-V to

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Learn RISC-V
 ================
 [![Check Markdown links](https://github.com/riscv/learn/actions/workflows/action.yml/badge.svg?branch=thong-phn%2Fcheck-markdown-links)](https://github.com/riscv/learn/actions/workflows/action.yml)
-[Fail Link](https://google.nett)
+
 A community-driven compilation of RISC-V resources and learning material. The list is dynamically
 updated by the community and categorized based on different contexts of the RISC-V scope, taking
 also into account different levels of experience/knowledge, allowing anyone interested in RISC-V to


### PR DESCRIPTION
Automatically checking markdown links for every git push using git CI.
Reference: https://github.com/marketplace/actions/markdown-link-check