### PR TITLE
Add rv32acim SGDH-RVSoC

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Explore open RISC-V implementations for hands-on learning.
 | **SERV** | SERV - The SErial RISC-V CPU. | [Github](https://github.com/olofk/serv) | 2024-18-10 |
 | **TinyRiscv** | A very simple and easy to understand RISC-V core | [Github](https://github.com/liangkangnan/tinyriscv) | 2024-18-10 |
 | **VexRiscv** | A FPGA Friendly 32 bit RISC-V CPU implementation | [Github](https://github.com/SpinalHDL/VexRiscv) | 2024-18-10 |
-
+| **SGDH-RVSoC** | An incredibly small 32-bit RISC-V rv32acim CPU capable of running Linux on FPGA, and software simulations | [Github](https://github.com/semisgdh/SGDH-RVSoC) | 2025-08-10 |
 ---
 
 ### Available RISC-V Boards, Development Kits, Tablets, and Laptops


### PR DESCRIPTION
32-bit RISC-V rv32acim CPU capable of running Linux on FPGA running on Arty A7-100T

This is the Posting for this RISC-32 project.
- https://www.linkedin.com/posts/yunseong-kim-linux-kernel_rtl-linux-kernel-activity-7263775016113049600-itNN
![1731818912494](https://github.com/user-attachments/assets/61d0ace9-4c41-4163-8c83-c2704e2acf1b)
