### PR TITLE
ci: fix failing Check Markdown Links (pin action-linkspector to v1.5.4)

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Run Linkspector
-        uses: umbrelladocs/action-linkspector@v1
+        uses: umbrelladocs/action-linkspector@v1.5.4
         with:
           reporter: github-check
           config_file: .linkspector.yml


### PR DESCRIPTION
## Problem

The **Check Markdown Links** workflow has been failing on `main` since PR #85 (2026-06-08). The failure is **not** broken links, it is a tooling regression in the linkspector action:

```
💥 Main error: Could not find Chrome (ver. 148.0.7778.97).
reviewdog: parse error: failed to unmarshal rdjson (DiagnosticResult): proto: syntax error
##[error]Process completed with exit code 1.
```

linkspector launches Chrome via Puppeteer; a bad Puppeteer/Chrome pairing made it crash before producing any output, so reviewdog failed to parse and the job exited 1 regardless of link health.

## Root cause

This is [UmbrellaDocs/action-linkspector#62](https://github.com/UmbrellaDocs/action-linkspector/issues/62) ("Could not find Chrome"), closed 2026-06-10 and fixed in **v1.5.3** (bumps linkspector to 0.5.5 / Puppeteer 25.1.0). Our workflow pinned the floating `@v1` tag, so it picked up the broken version.

## Fix

Pin the action to the fixed release **`@v1.5.4`**, matching this repo's tag-pinning style (`actions/checkout@v6`, `lychee-action@v2`) and preventing future silent breakage from `@v1` tag drift. No change to link-checking behavior or config (`.linkspector.yml`).

The pull_request run on this PR validates the fix.
