### PR TITLE
Add paper: An Educational RISC-V-Based 16-Bit Processor

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -8,3 +8,6 @@
 
 # star-history badge API is a dynamic image endpoint that intermittently 503s.
 ^https://api\.star-history\.com/
+
+# mdpi.com (Cloudflare) returns HTTP 403 to non-browser clients (anti-bot).
+^https://www\.mdpi\.com/

--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Popular hardware with RV64 based processors.
 <!-- Keep this sorted alphabetically =) -->
 | Resource | Author(s) | Description | Access |
 |---|---|---|---|
+| **An Educational RISC-V-Based 16-Bit Processor** | Jecel Mattos de Assumpção, Oswaldo Hideo Ando, Hugo Puertas de Araújo, Mario Gazziro | Peer-reviewed paper (MDPI Chips, 2024) describing a simplified 16-bit processor based on the RISC-V ISA, developed as a teaching platform for computer architecture and digital design. | [Article](https://www.mdpi.com/2674-0729/3/4/20) · [DOI](https://doi.org/10.3390/chips3040020) |
 | **Design of the RISC-V Instruction Set Architecture** | Andrew Waterman | PhD dissertation on the structure of the RISC-V ISA. | [PDF](https://www2.eecs.berkeley.edu/Pubs/TechRpts/2016/EECS-2016-1.pdf) |
 | **Is RISC-V the Future?** | Roddy Urquhart | Examination of RISC-V’s future potential. | [Article](https://semiengineering.com/is-risc-v-the-future) |
 | **Past, Present and Future of RISC-V** | Krste Asanović | Overview of RISC-V’s evolution. | [YouTube](https://www.youtube.com/watch?v=RrVRMFjYti0) |


### PR DESCRIPTION
## Add Resource — Articles and Presentations

Adds a peer-reviewed paper to the **Articles and Presentations** section:

**"An Educational RISC-V-Based 16-Bit Processor"**
Jecel Mattos de Assumpção, Oswaldo Hideo Ando, Hugo Puertas de Araújo, Mario Gazziro
*Chips* 2024, 3(4), 395–407. https://doi.org/10.3390/chips3040020
Article: https://www.mdpi.com/2674-0729/3/4/20

Source of the suggestion: https://www.mdpi.com/about/announcements/17763

### Changes
- `README.md` — new row inserted alphabetically at the top of the Articles table.
- `.lycheeignore` — allow-list `www.mdpi.com`, which returns HTTP 403 to non-browser clients (same anti-bot pattern already documented for raspberrypi.com). The paper is confirmed reachable in a browser; the `doi.org` link resolves normally.
